### PR TITLE
Fixed the framework build so that it packages the headers again. #20

### DIFF
--- a/Stubble.xcodeproj/project.pbxproj
+++ b/Stubble.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n${PROJECT_DIR}/${PROJECT_NAME}/Scripts/framework-builder";
+			shellScript = "set -e\nSTATIC_LIB_HEADER_DIR=include/Stubble ${PROJECT_DIR}/${PROJECT_NAME}/Scripts/framework-builder";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Stubble/Scripts/README.txt
+++ b/Stubble/Scripts/README.txt
@@ -1,0 +1,3 @@
+The framework-builder script was downloaded from
+https://github.com/csexton/ios-framework-builder/blob/master/standalone/framework-builder
+at version 65f2c9a9c573d26fb371be3be34f0e6553efbb47

--- a/Stubble/Scripts/framework-builder
+++ b/Stubble/Scripts/framework-builder
@@ -41,6 +41,8 @@ module IOSFrameworkBuilder
     end
 
     def call
+      FileUtils.rm_rf "#{dir}", :verbose => true
+
       FileUtils.mkdir_p "#{dir}/Versions/A/Headers", :verbose => true
       FileUtils.mkdir_p "#{dir}/Versions/A/Resources", :verbose => true
       FileUtils.ln_sf "A", "#{dir}/Versions/Current"
@@ -61,6 +63,10 @@ module IOSFrameworkBuilder
   class Builder
     include DeathRunner
     attr_accessor :name,
+      :static_lib_target,
+      :static_lib_name,
+      :static_lib_header_dir,
+      :static_lib_resources_dir,
       :build_dir,
       :build_root,
       :configuration,
@@ -72,6 +78,10 @@ module IOSFrameworkBuilder
 
     def initialize
       @name = ENV['PROJECT_NAME']
+      @static_lib_name = ENV['STATIC_LIB_NAME'] ? ENV['STATIC_LIB_NAME'] : @name
+      @static_lib_target = ENV['STATIC_LIB_TARGET'] ? ENV['STATIC_LIB_TARGET'] : @static_lib_name
+      @static_lib_header_dir = ENV['STATIC_LIB_HEADER_DIR'] ? ENV['STATIC_LIB_HEADER_DIR'] : "#{name}Headers"
+      @static_lib_resources_dir = ENV['STATIC_LIB_RESOURCES_DIR'] ? ENV['STATIC_LIB_RESOURCES_DIR'] : "#{name}Resources"
       @build_dir = ENV['BUILD_DIR']
       @build_root = ENV['BUILD_ROOT']
       @configuration = ENV['CONFIGURATION']
@@ -87,11 +97,11 @@ module IOSFrameworkBuilder
     end
 
     def header_path
-      "#{target_build_dir}/#{name}Headers/"
+      "#{target_build_dir}/#{static_lib_header_dir}/"
     end
 
     def resources_path
-      "#{target_build_dir}/#{name}Resources/"
+      "#{target_build_dir}/#{static_lib_resources_dir}/"
     end
 
     def call
@@ -118,12 +128,12 @@ module IOSFrameworkBuilder
     def default_opts
       {
         :project => project_file_path,
-        :target => name,
+        :target => static_lib_target,
         :configuration => configuration
       }
     end
     def binary_path(sdk)
-      "#{build_dir}/#{configuration}-#{sdk}/lib#{name}.a"
+      "#{build_dir}/#{configuration}-#{sdk}/lib#{static_lib_name}.a"
     end
 
     def format_opts(hash)


### PR DESCRIPTION
Pull request to fix broken framework build, which was broken because of a change in the location of the header paths (they are in an _include_ directory now).

This does the following:
- Updates the framework-builder script to the latest version, which let's us specify a header path as an argument.
- Updates the line that calls that script to include the header path.
- Adds a README to the Script directory alongside the _framework-builder_ script to that we know where to get it, and what version it is, since we check that script into source directly.
