### PR TITLE
Fixing verifyNoInteractions result when stubbing method -Mark

### DIFF
--- a/Stubble/SBLMockObject.h
+++ b/Stubble/SBLMockObject.h
@@ -10,7 +10,6 @@
 
 @property (nonatomic, readonly) SBLStubbedInvocation *sblCurrentStubbedInvocation;
 @property (nonatomic, readonly) SBLInvocationRecord *sblVerifyInvocation;
-@property (nonatomic, readonly) NSUInteger *sblNumberOfInvocations;
 
 - (SBLVerificationResult *)sblVerifyMockNotCalled;
 

--- a/Stubble/SBLMockObject.m
+++ b/Stubble/SBLMockObject.m
@@ -11,7 +11,6 @@
 @property (nonatomic, readonly) NSMutableArray *sblStubbedInvocations;
 @property (nonatomic, readonly) NSMutableArray *sblActualInvocations;
 @property (nonatomic, readwrite) SBLInvocationRecord *sblVerifyInvocation;
-@property (nonatomic, readwrite) NSUInteger *sblNumberOfInvocations;
 
 @end
 
@@ -29,7 +28,6 @@
     _sblBehavior = behavior;
     _sblStubbedInvocations = [NSMutableArray array];
     _sblActualInvocations = [NSMutableArray array];
-    _sblNumberOfInvocations = 0;
     return self;
 }
 
@@ -50,8 +48,6 @@
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation {
-    self.sblNumberOfInvocations++;
-
     if (SBLTransactionManager.currentTransactionManager.state == SBLTransactionManagerStateStubInProgress) {
         [self.sblStubbedInvocations addObject:[[SBLStubbedInvocation alloc] initWithInvocation:invocation]];
         [SBLTransactionManager.currentTransactionManager whenMethodInvokedForMock:self];
@@ -93,7 +89,7 @@
 }
 
 - (SBLVerificationResult *)sblVerifyMockNotCalled {
-    if ([self sblNumberOfInvocations]) {
+    if (self.sblActualInvocations.count) {
         return [[SBLVerificationResult alloc] initWithSuccess:NO failureDescription:SBLMethodWasCalledUnexpectedly];
     }
     return [[SBLVerificationResult alloc] initWithSuccess:YES failureDescription:nil];

--- a/StubbleTests/SBLVerifyTest.m
+++ b/StubbleTests/SBLVerifyTest.m
@@ -550,6 +550,15 @@
     XCTAssertNil(result.failureDescription);
 }
 
+- (void)testWhenVerifyingNoInteractionsWhenMethodStubbedThenResultIsSuccessful {
+    SBLTestingClass *mock = mock(SBLTestingClass.class);
+    [when([mock methodReturningBool]) thenReturn:@YES];
+    
+    SBLVerificationResult *result = SBLVerifyNoInteractionsImpl(mock);
+    XCTAssertTrue(result.successful);
+    XCTAssertNil(result.failureDescription);
+}
+
 - (void)testWhenVerifyingNoInteractionsWhenMockCalledThenTestFailsWithTheCorrectMessage {
     SBLTestingClass *mock = mock(SBLTestingClass.class);
 


### PR DESCRIPTION
I'll leave this PR up for discussion. Here's my scenario, in case there's a better way to do this:

In my `setUp`, I have a universal stub, something like `[when(mock.foo) thenReturn:@"bar"]`, that gets called for each test. However, `SBLVerifyNoInteractions(mock)` no longer works in the test methods of that file because of the previous stub. The current fix is to move the universal stub into every test except the no interactions test, which adds a crazy amount of code duplication.

My proposed solution is to remove the `sblNumberOfInvocations` property and verify that the mock is not called by counting the number of `sblActualInvocations`. I've added a unit test to reproduce my issue.
