### PR TITLE
Fix issue with printing description of actual objects.

### DIFF
--- a/Stubble/SBLMatcher.m
+++ b/Stubble/SBLMatcher.m
@@ -47,7 +47,7 @@ typedef void(^SBLMatcherPostInvocationMatchBlock)(SBLInvocationArgument *argumen
         BOOL argumentMatches = [object isEqual:argument.argument] || (!object && !argument.argument);
         SBLArgumentMatcherResult *argumentMatcherResult = [[SBLArgumentMatcherResult alloc] initWithMatches:argumentMatches
                                                          expectedArgument:object
-                                                           actualArgument:[argument.argument description]];
+                                                           actualArgument:argument.argument];
         return argumentMatcherResult;
 	}];
 }

--- a/StubbleTests/SBLTestingClass.h
+++ b/StubbleTests/SBLTestingClass.h
@@ -83,6 +83,8 @@ typedef void(^SBLTestingBlock)(int integer, NSObject *object);
 
 - (NSArray *)methodWithArray:(NSArray *)array;
 
+- (NSDictionary *)methodWithDictionary:(NSDictionary *)dictionary;
+
 - (NSString *)methodWithObject:(NSNumber *)number;
 
 - (void)methodWithCArray:(const char **)cArray;

--- a/StubbleTests/SBLTestingClass.m
+++ b/StubbleTests/SBLTestingClass.m
@@ -18,6 +18,10 @@
 	return array;
 }
 
+- (NSDictionary *)methodWithDictionary:(NSDictionary *)dictionary {
+    return dictionary;
+}
+
 - (id)methodWithVariableNumberOfArguments:(id)argument1, ... {
 	return @"";
 }

--- a/StubbleTests/SBLVerifyTest.m
+++ b/StubbleTests/SBLVerifyTest.m
@@ -291,6 +291,20 @@
     XCTAssertEqualObjects(result.failureDescription, expectedFailureDescription);
 }
 
+- (void)testWhenVerifyingForMethodWithDifferentDictionaryParametersThenHelpfulMessageIsReturned {
+    SBLTestingClass *mock = mock(SBLTestingClass.class);
+
+    [mock methodWithDictionary:@{@"key" : @"badValue"}];
+
+    NSString *expectedFailureMessageFormat = @"Method 'methodWithDictionary:' was called, but with differing arguments. Expected: %@ \rActual: %@";
+    SBLVerificationResult *result = SBLVerifyImpl(atLeast(1), nil, [mock methodWithDictionary:@{@"key" : @"goodValue"}]);
+    XCTAssertFalse(result.successful);
+    NSArray *actualArray = @[@{@"key" : @"badValue"}];
+    NSArray *expectedArray = @[@{@"key" : @"goodValue"}];
+    NSString *expectedFailureDescription = [NSString stringWithFormat:expectedFailureMessageFormat, expectedArray, actualArray];
+    XCTAssertEqualObjects(result.failureDescription, expectedFailureDescription);
+}
+
 - (void)testWhenVerifyingForMethodWithDifferentPrimitiveParametersThenHelpfulMessageIsReturned {
     SBLTestingClass *mock = mock(SBLTestingClass.class);
 


### PR DESCRIPTION
For objects like NSDictionary that have multiline descriptions, when the argument match failed, the failure message mangled the description of the actual object, squashing it into a single string with '\n' in place
of the newlines.

It looks like the issue was that description was called on the actual object before passing into the SBLArgumentMatcherResult. That was done as part of the refactoring in 38a50c1b, but I can't see any reason for it, and reverting it here doesn't break any other tests.
