### PR TITLE
Fix matching nil blocks; add tests for matching nil objects and blocks

### DIFF
--- a/Stubble/SBLInvocationRecord.m
+++ b/Stubble/SBLInvocationRecord.m
@@ -48,7 +48,9 @@
 						break;
 					}
 				}
-			} else {
+			}
+
+            if (!objectMatcher) {
 				objectMatcher = [SBLMatcher objectIsEqualMatcher:argument];
 			}
 		}

--- a/StubbleTests/SBLVerifyTest.m
+++ b/StubbleTests/SBLVerifyTest.m
@@ -101,6 +101,26 @@
     XCTAssertNil(result.failureDescription);
 }
 
+- (void)testWhenVerifyingNilObjectThatMatchesThenResultIsSuccessful {
+    SBLTestingClass *mock = mock(SBLTestingClass.class);
+
+    [mock methodWithObject:nil];
+
+    SBLVerificationResult *result = SBLVerifyImpl(atLeast(1), nil, [mock methodWithObject:nil]);
+
+    XCTAssertTrue(result.successful);
+}
+
+- (void)testWhenVerifyingNullBlockThatMatchesThenResultIsSuccessful {
+    SBLTestingClass *mock = mock(SBLTestingClass.class);
+
+    [mock methodWithBlock:NULL];
+
+    SBLVerificationResult *result = SBLVerifyImpl(times(1), nil, [mock methodWithBlock:NULL]);
+
+    XCTAssertTrue(result.successful);
+}
+
 #pragma mark - Verify Times Tests
 
 - (void)testWhenVerifyingExactlyZeroTimes_WhenNotCalled_ThenResultIsSuccessful {


### PR DESCRIPTION
Trying to verify that a method was invoked with nil passed in for a block argument fails erroneously. This patch fixes that problem. It appears that for blocks that weren't using any() or capture(), a value matcher was being set instead of an object matcher.

I added a test for nil objects just for good measure, even though that was already working.