### PR TITLE
Implemented a generic debugDescription

### DIFF
--- a/Stubble/SBLClassMockObjectBehavior.m
+++ b/Stubble/SBLClassMockObjectBehavior.m
@@ -92,6 +92,12 @@
     return [self.mockedClass conformsToProtocol:aProtocol];
 }
 
+- (NSString *)mockObjectDebugDescription {
+    const char * classNameCString = class_getName(self.mockedClass);
+    NSString *className = [[NSString alloc] initWithUTF8String:classNameCString];
+    return [NSString stringWithFormat:@"Mocking class %@", className];
+}
+
 - (NSString *)valueForCode:(NSString *)codeLetter fromAttributes:(NSArray *)attributes {
 	NSString *value = nil;
 	for (NSString *attribute in attributes) {

--- a/Stubble/SBLMockObject.m
+++ b/Stubble/SBLMockObject.m
@@ -156,6 +156,10 @@
     return [[SBLVerificationResult alloc] initWithSuccess:correctCallCount && correctOrder failureDescription:failureMessage];
 }
 
+- (NSString *)debugDescription {
+    return [self.sblBehavior mockObjectDebugDescription];
+}
+
 - (NSString *)sblCallCountFailureMessageForInvocationCount:(NSInteger)invocationCount mismatchedMethodCalls:(NSArray *)mismatchedMethodCalls formattedExpectedTimes:(NSString *)formattedTimes {
     NSString *failureMessage;
     if (mismatchedMethodCalls.count) {

--- a/Stubble/SBLMockObjectBehavior.h
+++ b/Stubble/SBLMockObjectBehavior.h
@@ -6,5 +6,6 @@
 - (BOOL)mockObjectRespondsToSelector:(SEL)aSelector;
 - (BOOL)mockObjectIsKindOfClass:(Class)aClass;
 - (BOOL)mockObjectConformsToProtocol:(Protocol *)aProtocol;
+- (NSString *)mockObjectDebugDescription;
 
 @end

--- a/Stubble/SBLProtocolMockObjectBehavior.m
+++ b/Stubble/SBLProtocolMockObjectBehavior.m
@@ -41,4 +41,10 @@
     return protocol_conformsToProtocol(self.mockedProtocol, aProtocol);
 }
 
+- (NSString *)mockObjectDebugDescription {
+    const char * protocolNameCString = protocol_getName(self.mockedProtocol);
+    NSString *protocolName = [[NSString alloc] initWithUTF8String:protocolNameCString];
+    return [NSString stringWithFormat:@"Mocking protocol %@", protocolName];
+}
+
 @end

--- a/StubbleTests/SBLStubTest.m
+++ b/StubbleTests/SBLStubTest.m
@@ -241,6 +241,24 @@
 	XCTAssertEqualObjects([mock protocolMethodWithInteger:3], @"1");
 }
 
+- (void)testWhenClassIsStubbedThenCorrectMockObjectDescriptionIsReturned {
+    SBLTestingClass *mock = mock(SBLTestingClass.class);
+    SBLMockObject *mockedObject = (SBLMockObject *)mock;
+
+    NSString *expectedDescription = @"Mocking class SBLTestingClass";
+    
+    XCTAssertEqualObjects([mockedObject debugDescription], expectedDescription);
+}
+
+- (void)testWhenProtocolIsStubbedThenCorrectMockObjectDescriptionIsReturned {
+    id<SBLTestingProtocol> mock = mock(@protocol(SBLTestingProtocol));
+    SBLMockObject *mockedProtocol = (SBLMockObject *)mock;
+    
+    NSString *expectedDescription = @"Mocking protocol SBLTestingProtocol";
+    
+    XCTAssertEqualObjects([mockedProtocol debugDescription], expectedDescription);
+}
+
 - (void)testWhenIntegerNumberIsReturnedFromStubMethodThatReturnsADoubleThenTheCorrectValueIsReturned {
     SBLTestingClass *mock = mock(SBLTestingClass.class);
 


### PR DESCRIPTION
Added mockObjectDebugDescription to SBLMockObjectBehavior and implemented in the class and protocol strategies a generic description to give the name of the class or protocol that is being mocked.

Added associated tests to SBLStubTest.  The rational for casting the mock in the tests to SBLMockObject is  when we are in debug mode working with a mocked class or protocol SBLMockObject is the type of the mocked class or protocol.